### PR TITLE
changed the mint method to mintToSelf

### DIFF
--- a/scripts/6-print-money.js
+++ b/scripts/6-print-money.js
@@ -8,7 +8,7 @@ const token = sdk.getToken("0x29504A69a2A81F9030186de7F2F41Ef4cade1f4a");
         // What's the max supply you want to set? 1,000,000 is a nice number!
         const amount = 1_000_000;
         // Interact with your deployed ERC-20 contract and mint the tokens!
-        await token.mint(amount);
+        await token.mintToSelf(amount);
         const totalSupply = await token.totalSupply();
 
         // Print out how many of our token's are out there now!


### PR DESCRIPTION
token.mint has been deprecated. mintToSelf is the correct method now.
link to the docs - https://portal.thirdweb.com/typescript/sdk.token.minttoself